### PR TITLE
Add option to assign group to user

### DIFF
--- a/src/Czertainly.Auth/Controllers/UsersController.cs
+++ b/src/Czertainly.Auth/Controllers/UsersController.cs
@@ -38,9 +38,11 @@ namespace Czertainly.Auth.Controllers
         }
 
         [HttpGet("users")]
-        public async Task<ActionResult<PagedResponse<UserDto>>> GetUsersAsync()
+
+        public async Task<ActionResult<PagedResponse<UserDto>>> GetUsersAsync([FromQuery] string? group)
+        //public async Task<ActionResult<PagedResponse<UserDto>>> GetUsersAsync()
         {
-            var result = await _userService.GetAsync(new QueryRequestDto());
+            var result = await _userService.GetAsync(new UserQueryRequestDto { Group = group });
 
             return Ok(result);
         }

--- a/src/Czertainly.Auth/Data/Migrations/20230605142708_AddUserGroup.Designer.cs
+++ b/src/Czertainly.Auth/Data/Migrations/20230605142708_AddUserGroup.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Czertainly.Auth.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,10 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Czertainly.Auth.Data.Migrations
 {
     [DbContext(typeof(AuthDbContext))]
-    partial class AuthDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230605142708_AddUserGroup")]
+    partial class AddUserGroup
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Czertainly.Auth/Data/Migrations/20230605142708_AddUserGroup.cs
+++ b/src/Czertainly.Auth/Data/Migrations/20230605142708_AddUserGroup.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Czertainly.Auth.Data.Migrations
+{
+    public partial class AddUserGroup : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "group_name",
+                schema: "auth",
+                table: "user",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "group_uuid",
+                schema: "auth",
+                table: "user",
+                type: "uuid",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "group_name",
+                schema: "auth",
+                table: "user");
+
+            migrationBuilder.DropColumn(
+                name: "group_uuid",
+                schema: "auth",
+                table: "user");
+        }
+    }
+}

--- a/src/Czertainly.Auth/Models/Dto/UserDto.cs
+++ b/src/Czertainly.Auth/Models/Dto/UserDto.cs
@@ -16,6 +16,10 @@ namespace Czertainly.Auth.Models.Dto
 
         public string? Description { get; init; }
 
+        public string? GroupName { get; init; }
+
+        public Guid? GroupUuid { get; init; }
+
         [Required]
         public bool Enabled { get; init; }
 

--- a/src/Czertainly.Auth/Models/Dto/UserQueryRequestDto.cs
+++ b/src/Czertainly.Auth/Models/Dto/UserQueryRequestDto.cs
@@ -1,0 +1,13 @@
+﻿using Czertainly.Auth.Common.Models.Dto;
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace Czertainly.Auth.Models.Dto
+{
+    public record UserQueryRequestDto : QueryRequestDto
+    {
+        [JsonPropertyName("group")]
+        public string? Group { get; init; }
+
+    }
+}

--- a/src/Czertainly.Auth/Models/Dto/UserRequestDto.cs
+++ b/src/Czertainly.Auth/Models/Dto/UserRequestDto.cs
@@ -21,6 +21,10 @@ namespace Czertainly.Auth.Models.Dto
 
         public string? Description { get; init; }
 
+        public string? GroupName { get; init; }
+
+        public Guid? GroupUuid { get; init; }
+
         public Guid? CertificateUuid { get; init; }
 
         public string? CertificateFingerprint { get; init; }

--- a/src/Czertainly.Auth/Models/Dto/UserUpdateRequestDto.cs
+++ b/src/Czertainly.Auth/Models/Dto/UserUpdateRequestDto.cs
@@ -14,6 +14,9 @@ namespace Czertainly.Auth.Models.Dto
 
         public string? Description { get; init; }
 
+        public string? GroupName { get; init; }
+
+        public Guid? GroupUuid { get; init; }
 
         public Guid? CertificateUuid { get; init; }
         public string? CertificateFingerprint { get; init; }

--- a/src/Czertainly.Auth/Models/Entities/User.cs
+++ b/src/Czertainly.Auth/Models/Entities/User.cs
@@ -25,6 +25,12 @@ public class User : TimestampedEntity
     [Column("description")]
     public string? Description { get; set; }
 
+    [Column("group_name")]
+    public string? GroupName { get; set; }
+
+    [Column("group_uuid")]
+    public Guid? GroupUuid { get; set; }
+
     [Required]
     [Column("enabled")]
     public bool Enabled { get; set; }

--- a/src/Czertainly.Auth/Services/UserService.cs
+++ b/src/Czertainly.Auth/Services/UserService.cs
@@ -1,4 +1,5 @@
 ﻿using AutoMapper;
+using Czertainly.Auth.Common.Data;
 using Czertainly.Auth.Common.Exceptions;
 using Czertainly.Auth.Common.Models.Dto;
 using Czertainly.Auth.Common.Services;
@@ -27,6 +28,24 @@ namespace Czertainly.Auth.Services
 
             _roleService = roleService;
             _permissionService = permissionService;
+        }
+
+        public override async Task<PagedResponse<UserDto>> GetAsync(IQueryRequestDto dto)
+        {
+            string? groupName = null;
+            if(dto is UserQueryRequestDto queryDto)
+            {
+                groupName = queryDto.Group;
+            }
+
+            var queryParams = _mapper.Map<QueryStringParameters>(dto);
+            var users = await (groupName == null ? _repository.GetAllAsync(queryParams) : _repository.GetWhereAsync(queryParams, u => u.GroupName == groupName));
+
+            return new PagedResponse<UserDto>
+            {
+                Data = _mapper.Map<List<UserDto>>(users),
+                Links = _mapper.Map<PagingMetadata>(users),
+            };
         }
 
         public override async Task<UserDetailDto> CreateAsync(ICrudRequestDto dto)


### PR DESCRIPTION
- Groups are managed in Core, but stored as user property
- Listing of users now accepts query parameter to filter users by group